### PR TITLE
[DEVO-746]sftp update

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ gradle shadowJar
 
 ### Publish
 
-First publish a new release to [JFrog Artifactory](https://simondata.jfrog.io/ui/repos/tree/General/gradle-virtual/gradle-int/simon/sftp-extractor)
+First publish a new release to [JFrog Artifactory](https://simondata.jfrog.io/ui/repos/tree/General/gradle-virtual/gradle-int/sftp-extractor)
 ```sh
 gradle clean shadowJar artifactoryPublish
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@
 gradle shadowJar
 ```
 
+### Publish
+
+First publish a new release to [JFrog Artifactory](https://simondata.jfrog.io/ui/repos/tree/General/gradle-virtual/gradle-int/simon/sftp-extractor)
+```sh
+gradle clean shadowJar artifactoryPublish
+```
+
+You will see a version pushed like `sftp-extractor-0.0.x-all.jar` in the output of the publish.
+
+Next, update Jenkins build argument for the version to pull into the container.
+[Jenkins Build Base Container](https://misc.automation.simondata.net/job/build-base-web-container/configure)
+
 ### Run
 Required Parameters:
 * `-u` `--user`: The username to connect with (required)
@@ -42,24 +54,6 @@ java -jar build/libs/sql-extractor/sql-extractor-1.0-SNAPSHOT-all.jar \
 ### Tests
 ```$sh
 gradle test
-```
-
-### Deploy
-
-Currently we run this via Python (see `java_sftp.py`) in Jenkins. Deploying has two steps.
-First, we copy the fat jar up to S3, and then we copy that file to each Jenkins box.
-
-```$sh
-aws s3 cp build/libs/sftp-extractor-1.0-SNAPSHOT-all.jar s3://prod.radi.co/build/libs/sftp-extractor-1.0-SNAPSHOT-all.jar
-
-djprod fab <nameTBD>
-```
-
-### Publish
-
-Publish a new release to JFrog Artifactory
-```sh
-gradle artifactoryPublish
 ```
 
 ## Additional Information

--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,6 @@ task sourceJar(type: Jar, dependsOn: classes) {
 
 publishing {
     publications {
-        //mavenJava(MavenPublication) {
         shadow(MavenPublication) { publication ->
             from project.shadow.component(publication)
             artifactId = 'sftp-extractor'

--- a/build.gradle
+++ b/build.gradle
@@ -13,14 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
  */
 
-group 'simon'
-
 apply plugin: 'java'
 apply plugin: 'signing'
 apply plugin: 'application'
 apply plugin: 'com.github.johnrengelman.shadow'
-apply plugin: 'net.researchgate.release'
-apply plugin: 'org.ajoberstar.git-publish'
 apply plugin: 'java-library'
 apply plugin: 'maven-publish'
 apply plugin: "com.jfrog.artifactory"
@@ -118,42 +114,19 @@ allprojects {
     apply plugin: "com.jfrog.artifactory"
 }
 
-release {
-    preTagCommitMessage = '[Gradle Release Plugin] - pre tag commit: '
-    tagCommitMessage = '[Gradle Release Plugin] - creating tag: '
-    newVersionCommitMessage = '[Gradle Release Plugin] - new version commit: '
-    tagTemplate = '${version}'
-    versionPropertyFile = 'gradle.properties'
-    buildTasks = ['build', 'shadowJar']
-    scmAdapters = [net.researchgate.release.GitAdapter]
-    git {
-        requireBranch = 'master'
-        pushToRemote = 'origin'
-        pushToBranchPrefix = ''
-        commitVersionFileOnly = false
-        signTag = false
-    }
-}
-
-
-task sourcesJar(type: Jar) {
+task sourceJar(type: Jar, dependsOn: classes) {
     from sourceSets.main.allJava
     archiveClassifier = 'sources'
 }
 
-task javadocJar(type: Jar) {
-    from javadoc
-    archiveClassifier = 'javadoc'
-}
-
-
 publishing {
     publications {
-        mavenJava(MavenPublication) {
+        //mavenJava(MavenPublication) {
+        shadow(MavenPublication) { publication ->
+            from project.shadow.component(publication)
             artifactId = 'sftp-extractor'
-            from components.java
-            artifact sourcesJar
-            artifact javadocJar
+            artifact sourceJar
+            artifact shadowJar
             versionMapping {
                 usage('java-api') {
                     fromResolutionOf('runtimeClasspath')
@@ -203,27 +176,9 @@ publishing {
 }
 
 signing {
-    sign publishing.publications.mavenJava
-}
-
-
-javadoc {
-    if(JavaVersion.current().isJava9Compatible()) {
-        options.addBooleanOption('html5', true)
-    }
-}
-
-gitPublish {
-    repoUri = 'git@github.com:Radico/sftp-extractor.git'
-    referenceRepoUri = System.getProperty("user.dir")
-    branch = 'gh-pages'
-    repoDir = file("$buildDir/git-publish") // defaults to $buildDir/gitPublish
-
-    contents {
-        from 'src/pages'
-        from(javadoc) {
-            into 'api'
-        }
+    setRequired {
+        // signing is only required if the artifacts are to be published
+        gradle.taskGraph.allTasks.any { it.equals( PublishToMavenRepository) }
     }
 }
 
@@ -238,9 +193,11 @@ artifactory {
 
         }
         defaults {
-            //publications ('ivyJava','mavenJava')
+            publications ('shadow')
             //List of Gradle Configurations (names or objects) from which to collect the list of artifacts to be deployed to Artifactory.
-            publishConfigs('archives', 'published')
+            publishBuildInfo = false
+            publishPom = false
+            publishIvy = false
         }
     }
     resolve {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.0.2
+version=0.0.3
 artifactory_contextUrl=https://simondata.jfrog.io/artifactory/gradle-virtual


### PR DESCRIPTION
* Update README with build/publish information and link to JFrog
* Clean up gradle script for publishing
    * Gradle `mavenJava` publication is the standard thin jar, not the shadow "fat" jar. This was getting picked up in the original publishing directives and overlooked when Artifactory plugin was added. Fix this to use the `shadow` jar
    * Remove broken javadocs - not enough comments to publish docs
    * Remove unused git publish and release plugins
    * Remove `group` which doesn't match the repository group in the pom that is published to Artifactory
    * Bump version